### PR TITLE
Fix README.md examples: absolute path to mounted directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,8 @@ PWD = $(shell pwd)
 repl:
 	docker run -it --rm -v $(PWD):/var/app sleepyfox/racket racket
 
+file:
+	docker run -it --rm -v $(PWD):/var/app sleepyfox/racket racket -t $(src)
+
 build:
 	docker build -t sleepyfox/racket .

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ To start a REPL simply:
 ```
 Or long-hand:
 ```bash
-  docker run -it --rm -v .:/var/app sleepyfox/racket
+  docker run -it --rm -v $(pwd):/var/app sleepyfox/racket
 ```
 
 To run a racket application of your own in the container:
 ```bash
-  docker run -it --rm -v .:/var/app sleepyfox/racket _my_app_.rkt
+  docker run -it --rm -v $(pwd):/var/app sleepyfox/racket _my_app_.rkt
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ Or long-hand:
   docker run -it --rm -v $(pwd):/var/app sleepyfox/racket
 ```
 
-To run a racket application of your own in the container:
+To run a racket application of your own in the container. Filename must be relative to current directory:
+```bash
+  make file src=_my_app.rkt
+```
+Or long-hand:
 ```bash
   docker run -it --rm -v $(pwd):/var/app sleepyfox/racket _my_app_.rkt
 ```


### PR DESCRIPTION
This thing is done correctly in `Makefile`, apparently wrong in `README`
